### PR TITLE
Fix freebsd build issues for ftconvert

### DIFF
--- a/flowtuple-convert/Makefile
+++ b/flowtuple-convert/Makefile
@@ -2,6 +2,7 @@ TARGET = ftconvert
 LIBS = -lwandio -lflowtuple -lcorsaro -ltrace -lJudy
 CC = gcc
 CFLAGS = -g -Wall -O2
+LDFLAGS=
 
 .PHONY: default all clean
 
@@ -17,7 +18,7 @@ HEADERS= $(wildcard *.h)
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
 $(TARGET): $(OBJECTS)
-	$(CC) $(OBJECTS) -Wall -o $@ $(LIBS)
+	$(CC) $(OBJECTS) -Wall -o $@ $(LDFLAGS) $(LIBS)
 
 clean:
 	-rm -f *.o

--- a/flowtuple-convert/ftconvert.c
+++ b/flowtuple-convert/ftconvert.c
@@ -5,6 +5,7 @@
 #include <getopt.h>
 #include <arpa/inet.h>
 #include <Judy.h>
+#include <sys/time.h>
 
 #include <flowtuple.h>
 #include <libcorsaro_avro.h>


### PR DESCRIPTION
 * Make sure timeval is properly defined
 * Add LDFLAGS to Makefile so that it can be overriden by the user