### PR TITLE
Update FT4 to include "spoofed" and "masscan" packet counters

### DIFF
--- a/flowtuple-convert/README.md
+++ b/flowtuple-convert/README.md
@@ -64,7 +64,7 @@ Convert flowtuple3 files into 5 minutely flowtuple4 files, aggregating
 destination IPs into /16s:
 
 ```
-  ftconvert -o "example/avro/v3_5min_example_%s.ft.avro" -V 2 -n 16 -I 5 \
+  ftconvert -o "example/avro/v3_5min_example_%s.ft.avro" -V 3 -n 16 -I 5 \
      ~/avrodownloads/ucsd-nt.161532*.avro
 ```
 


### PR DESCRIPTION
This replicates data fields that we previously had in FT3, but dropped during the FT4 design (mainly because the old fields were boolean flags which didn't necessarily translate to our new aggregated flowtuples).